### PR TITLE
infra: EU residency — Vercel fra1 pin + Bunny Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,15 +12,10 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/public/favicon/favicon-32x32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
 
-    <!-- Google Font -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <!-- Inter font via Bunny Fonts (GDPR-compliant, EU-hosted Google Fonts mirror) -->
+    <link rel="preconnect" href="https://fonts.bunny.net" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700;800;900&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800;900&display=swap"
+      href="https://fonts.bunny.net/css?family=inter:300,400,500,600,700,800,900&display=swap"
       rel="stylesheet"
     />
 
@@ -28,9 +23,9 @@
 
     <meta
       name="description"
-      content="The starting point for your next project with Minimal UI Kit, built on the newest version of Material-UI ©, ready to be customized to your style"
+      content="SmartDiagnosis - AI-Powered Clinical Intelligence for Complex Medical Diagnoses. Faster, more accurate differential diagnosis with rare disease detection."
     />
-    <meta name="keywords" content="react,material,kit,application,dashboard,admin,template" />
+    <meta name="keywords" content="medical,diagnosis,AI,clinical,intelligence,rare,disease,healthcare" />
   </head>
 
   <body>

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "regions": ["fra1"],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Pin Vercel deployments to `fra1` (Frankfurt) instead of default US regions
- Swap `fonts.googleapis.com` → `fonts.bunny.net` (GDPR-compliant mirror of Google Fonts, EU-hosted)

Aligns the frontend with the EU residency commitment made in the accelerator due-diligence response. Backend was already migrated to `eu-central-1` in commit ferced/SmartDiagnosis@8f882e9.

## Test plan
- [x] `vercel.json` is valid JSON (locally validated)
- [ ] After merge: confirm Vercel deploys this build to fra1 (check deployment region in dashboard)
- [ ] After merge: confirm Inter font still renders correctly on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)