### PR TITLE
fix(diagnosis): keep rare disease confirmation non-destructive

### DIFF
--- a/src/sections/product/view/response-details-form.tsx
+++ b/src/sections/product/view/response-details-form.tsx
@@ -237,39 +237,47 @@ export default function ResponseDetails({
     setError(null);
   };
 
-  const displayDiagnoses = finalDiagnosis ? [finalDiagnosis] : diagnosesData;
+  const displayDiagnoses = diagnosesData;
 
   const handleTestResult = async (decision: string, action: any, rareDiseaseId: string) => {
     if (decision === 'CONFIRM' && action.shouldBecomePrimary) {
       const rareDisease = rareDiseasesData?.find((d: DiagnosisDetail) => d.diagnosis === rareDiseaseId);
       if (rareDisease) {
-        const currentTimestamp = Math.floor(Date.now() / 1000).toString();
-        const diagnosesToArchive: ArchivedDiagnosis[] = diagnosesData.map((diag: DiagnosisDetail) => ({
-          diagnosis: diag.diagnosis,
-          treatment: diag.treatment,
-          probability: diag.probability,
-          timestamp: currentTimestamp,
-          reason: `Test confirmed rare disease: ${rareDisease.diagnosis}`,
-        }));
-
-        setArchivedDiagnoses(prev => [...prev, ...diagnosesToArchive]);
-
-        const updatedRareDisease = {
+        const confirmedRareDisease: DiagnosisDetail = {
           ...rareDisease,
           probability: action.probability || rareDisease.probability,
           treatment: action.updatedDiagnosis?.treatment || rareDisease.treatment,
+          testConfirmed: true,
         };
 
-        setFinalDiagnosis(updatedRareDisease);
+        const remainingRareDiagnoses = (rareDiseasesData || []).filter(
+          (d: DiagnosisDetail) => d.diagnosis !== rareDiseaseId
+        );
 
-        setResponseDetails((prev: any) => ({
-          ...prev,
-          diagnoses: {
-            ...prev.diagnoses,
-            common_diagnoses: [updatedRareDisease],
-            rare_diagnoses: [],
-          }
-        }));
+        setPreservedRareDiagnoses(remainingRareDiagnoses);
+
+        const auditEntry: ArchivedDiagnosis = {
+          diagnosis: confirmedRareDisease.diagnosis,
+          treatment: confirmedRareDisease.treatment,
+          probability: confirmedRareDisease.probability,
+          timestamp: Math.floor(Date.now() / 1000).toString(),
+          reason: `Promoted from rare diseases panel after positive test result`,
+        };
+        setArchivedDiagnoses(prev => [...prev, auditEntry]);
+
+        setResponseDetails((prev: any) => {
+          const prevDiagnoses = prev?.diagnoses || (prev as any)?.followUpResponse || {};
+          const existingCommon: DiagnosisDetail[] = prevDiagnoses.common_diagnoses || [];
+          const dedupedCommon = existingCommon.filter((d) => d.diagnosis !== rareDiseaseId);
+          return {
+            ...prev,
+            diagnoses: {
+              ...prevDiagnoses,
+              common_diagnoses: [confirmedRareDisease, ...dedupedCommon],
+              rare_diagnoses: remainingRareDiagnoses,
+            },
+          };
+        });
 
         setActiveStep(0);
       }
@@ -379,27 +387,31 @@ export default function ResponseDetails({
                     maxWidth: '100%',
                     mx: 'auto',
                     bgcolor: theme.palette.background.paper,
-                    boxShadow: finalDiagnosis
+                    boxShadow: (finalDiagnosis || details.testConfirmed)
                       ? theme.customShadows?.success || '0px 8px 32px rgba(0, 137, 123, 0.2)'
                       : theme.customShadows?.card || '0px 4px 20px rgba(0, 0, 0, 0.1)',
                     borderRadius: '8px',
                     transition: 'all 0.5s ease-in-out',
-                    transform: finalDiagnosis ? 'scale(1.02)' : 'scale(1)',
-                    border: finalDiagnosis ? `2px solid ${theme.palette.success.dark}` : 'none',
+                    transform: (finalDiagnosis || details.testConfirmed) ? 'scale(1.02)' : 'scale(1)',
+                    border: (finalDiagnosis || details.testConfirmed) ? `2px solid ${theme.palette.success.dark}` : 'none',
                   }}
                 >
                   <Box
                     sx={{
-                      backgroundColor: finalDiagnosis ? theme.palette.success.dark : theme.palette.info.dark,
+                      backgroundColor: (finalDiagnosis || details.testConfirmed) ? theme.palette.success.dark : theme.palette.info.dark,
                       color: theme.palette.common.white,
                       p: 3,
                       textAlign: 'center',
                     }}
                   >
                     <Box display="flex" alignItems="center" justifyContent="center" gap={1}>
-                      {finalDiagnosis && <CheckCircleOutline sx={{ fontSize: 36 }} />}
+                      {(finalDiagnosis || details.testConfirmed) && <CheckCircleOutline sx={{ fontSize: 36 }} />}
                       <Typography variant="h4">
-                        {finalDiagnosis ? 'Confirmed Diagnosis' : `Diagnosis Result ${idx + 1}`}
+                        {details.testConfirmed
+                          ? 'Test-confirmed Diagnosis'
+                          : finalDiagnosis
+                            ? 'Confirmed Diagnosis'
+                            : `Diagnosis Result ${idx + 1}`}
                       </Typography>
                     </Box>
                   </Box>

--- a/src/sections/product/view/response-details-form.tsx
+++ b/src/sections/product/view/response-details-form.tsx
@@ -407,11 +407,11 @@ export default function ResponseDetails({
                     <Box display="flex" alignItems="center" justifyContent="center" gap={1}>
                       {(finalDiagnosis || details.testConfirmed) && <CheckCircleOutline sx={{ fontSize: 36 }} />}
                       <Typography variant="h4">
-                        {details.testConfirmed
-                          ? 'Test-confirmed Diagnosis'
-                          : finalDiagnosis
-                            ? 'Confirmed Diagnosis'
-                            : `Diagnosis Result ${idx + 1}`}
+                        {(() => {
+                          if (details.testConfirmed) return 'Test-confirmed Diagnosis';
+                          if (finalDiagnosis) return 'Confirmed Diagnosis';
+                          return `Diagnosis Result ${idx + 1}`;
+                        })()}
                       </Typography>
                     </Box>
                   </Box>

--- a/src/sections/product/view/types.ts
+++ b/src/sections/product/view/types.ts
@@ -5,6 +5,7 @@ export interface DiagnosisDetail {
   prevalence?: string;
   discriminatorSymptoms?: string[];
   recommendedTests?: string[];
+  testConfirmed?: boolean;
 }
 
 export interface DiagnosisData {


### PR DESCRIPTION
## Summary
- Confirming a rare disease via the test panel no longer locks the UI into a single-diagnosis "final" state with no way back.
- The confirmed disease is prepended to the differential with a `testConfirmed` flag, other candidates stay visible as alternatives, and the follow-up flow remains available so the model can keep refining.
- Per-card visual cue (success styling + "Test-confirmed Diagnosis" heading) is now driven by a per-diagnosis flag instead of the global `finalDiagnosis` lock.

## Background
Reported by Sean in testing:
> Cuando alguien testeando selecciona una rare disease y el sistema la toma como que es esa, ya se queda con ese diagnostico y como que no "piensa mas" que pueda cambiar o que se pueda volver atras.

Root cause: the `CONFIRM + shouldBecomePrimary` branch in `handleTestResult` was destructive — it called `setFinalDiagnosis(...)`, replaced `common_diagnoses` with `[rareDisease]`, and cleared `rare_diagnoses`. That triggered `displayDiagnoses = [finalDiagnosis]` (single card), hid the follow-up button via the `!finalDiagnosis` gate, and offered no undo path. The `RULE_OUT` branch right next to it was already non-destructive — this fix brings `CONFIRM` in line.

## Changes
- `src/sections/product/view/response-details-form.tsx`
  - `handleTestResult` CONFIRM branch: prepend confirmed disease to `common_diagnoses`, remove from `rare_diagnoses`, archive an audit entry, **no longer sets `finalDiagnosis`**.
  - `displayDiagnoses` no longer collapses to `[finalDiagnosis]`; the 3-follow-up "final" path still works because that flow itself overwrites `common_diagnoses` to `[finalDiag]`.
  - Per-card success styling / heading driven by `details.testConfirmed` in addition to `finalDiagnosis`.
- `src/sections/product/view/types.ts`
  - Add `testConfirmed?: boolean` to `DiagnosisDetail`.

## Test plan
- [ ] On the Vercel preview, log in and run a diagnosis that returns rare diseases.
- [ ] Mark a rare disease "Present" → submit tests with a positive-confirming result.
- [ ] Verify the confirmed disease appears as **step 1** with success styling and "Test-confirmed Diagnosis" header, while the original differential candidates remain visible as steps 2..N.
- [ ] Verify the rare-disease panel no longer lists the confirmed one, but still lists the others.
- [ ] Verify the **Follow Up Questions** button stays available (so the system can keep reasoning).
- [ ] Verify the 3-follow-up "final diagnosis reached" path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)