### PR TITLE
fix(model): default UI model to GPT-5.5

### DIFF
--- a/src/components/openai-config/openai-config-modal.tsx
+++ b/src/components/openai-config/openai-config-modal.tsx
@@ -65,7 +65,7 @@ export default function OpenAIConfigModal({
     initialConfig
 }: OpenAIConfigModalProps) {
     const [apiKey, setApiKey] = useState(initialConfig?.apiKey || '');
-    const [selectedModel, setSelectedModel] = useState(initialConfig?.model || 'gpt-4o');
+    const [selectedModel, setSelectedModel] = useState(initialConfig?.model || 'gpt-5.5');
     const [models, setModels] = useState<OpenAIModel[]>([]);
     const [isValidating, setIsValidating] = useState(false);
     const [validationError, setValidationError] = useState<string | null>(null);
@@ -178,7 +178,7 @@ export default function OpenAIConfigModal({
                         <Alert severity="info">
                             <Typography variant="body2">
                                 Configure your own OpenAI API key to use your preferred model and manage your own costs.
-                                Leave empty to use the system default (GPT-4o).
+                                Leave empty to use the system default (GPT-5.5).
                             </Typography>
                         </Alert>
 

--- a/src/sections/product/view/main-form.tsx
+++ b/src/sections/product/view/main-form.tsx
@@ -162,7 +162,7 @@ export default function MainForm({
                     AI Model:
                   </Typography>
                   <Chip
-                    label={openAIConfig ? openAIConfig.model : 'GPT-4o (Default)'}
+                    label={openAIConfig ? openAIConfig.model : 'GPT-5.5 (Default)'}
                     color={openAIConfig ? 'primary' : 'default'}
                     size="small"
                   />


### PR DESCRIPTION
Saca el hardcode de gpt-4o en el front (default del selector + 2 textos). Alinea con el default del backend (gpt-5.5). La lista de modelos ya viene de /openai/models.